### PR TITLE
Bug fix: Update index.ts to remove toReactElement.ts

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,7 +1,6 @@
 import satori, { type SatoriOptions } from 'satori';
 import { Resvg, type ResvgRenderOptions } from '@resvg/resvg-js';
 import type { SvelteComponent } from 'svelte';
-import toReactElement from './toReactElement';
 
 const fontFile = await fetch('https://sveltekit-og.ethercorps.io/noto-sans.ttf');
 const fontData: ArrayBuffer = await fontFile.arrayBuffer();
@@ -76,4 +75,4 @@ type ImageOptions = {
 
 type ImageResponseType = typeof ImageResponse;
 
-export { componentToImageResponse, ImageResponse, toReactElement, type ImageResponseType };
+export { componentToImageResponse, ImageResponse, type ImageResponseType };


### PR DESCRIPTION
Easier to communicate via a minimal PR. I didn't remove the `toReactElement.ts` file though.

Bug:
1. `npm i @ethercorps/sveltekit-og`
2. Add code from https://github.com/etherCorps/sveltekit-og#quick-start
3. Visit `http://localhost:5173/og`. This error is returned:

```
Internal server error: Cannot find module '/myapp/node_modules/@ethercorps/sveltekit-og/toReactElement' imported from /myapp/node_modules/@ethercorps/sveltekit-og/index.js
```

Making the changes in the PR removes this error and allows the image to be generated.