### PR TITLE
Update getting started code to use recommended og dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ const fontData: ArrayBuffer = await fontFile.arrayBuffer();
 
 export const GET: RequestHandler = async () => {
 	return await ImageResponse(template, {
-		height: 250,
-		width: 500,
+		height: 630,
+		width: 1200,
 		fonts: [
 			{
 				name: 'Inter Latin',


### PR DESCRIPTION
It appears 1.91:1 image ratio is required and [Facebook recommends 1200x630](https://developers.facebook.com/docs/sharing/webmasters/images) such as used in your API reference. Updating the Getting Started code to use 1200x630 would help new users start on the right track.