### PR TITLE
use .js extension when importing toReactElement.js

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,6 +1,6 @@
 import satori, { type SatoriOptions } from 'satori';
 import type { SvelteComponent } from 'svelte';
-import toReactElement from './toReactElement';
+import toReactElement from './toReactElement.js';
 import { svg2png, initialize, type ConvertOptions } from 'svg2png-wasm';
 
 let initialized = false;


### PR DESCRIPTION
To avoid this error:

Internal server error: Cannot find module
'/myapp/node_modules/@ethercorps/sveltekit-og/toReactElement'
imported from
/myapp/node_modules/@ethercorps/sveltekit-og/index.js

