### PR TITLE
Automate publishing to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,3 +18,4 @@ jobs:
       - uses: JS-DevTools/npm-publish@v2
         with:
           token: ${{ secrets.NPM_TOKEN }}
+          package: "package"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           node-version: "lts"
       - run: pnpm install
+      - run: pnpm build
       #- run: pnpm test
       - uses: JS-DevTools/npm-publish@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches: main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "lts"
+      - run: pnpm install
+      #- run: pnpm test
+      - uses: JS-DevTools/npm-publish@v2
+        with:
+          token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
I thought this might be helpful for you.

You'd just need to [generate an NPM Token](https://docs.npmjs.com/creating-and-viewing-access-tokens) with the `automation` permission and add `NPM_TOKEN` as a secret on this Github repo.

Then any PR that is merged to `main` that bumps the version # in package.json will be automatically published to NPM.

There don't appear to be any tests in `etherCorps/sveltekit-og` currently, so I left a comment there; enabling this line will only publish to NPM only if tests pass successfully.

