### PR TITLE
Convert tab to space for Usage code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ const fontFile = await fetch('https://og-playground.vercel.app/inter-latin-ext-4
 const fontData: ArrayBuffer = await fontFile.arrayBuffer();
 
 export const GET: RequestHandler = async () => {
-	return await ImageResponse(template, {
-		height: 630,
-		width: 1200,
-		fonts: [
-			{
-				name: 'Inter Latin',
-				data: fontData,
-				weight: 400
-			}
-		]
-	});
+  return await ImageResponse(template, {
+    height: 630,
+    width: 1200,
+    fonts: [
+      {
+        name: 'Inter Latin',
+        data: fontData,
+        weight: 400
+      }
+    ]
+  });
 };
 ```
 


### PR DESCRIPTION
Formats the code nicer. Github makes tabs look bad.